### PR TITLE
Add access_token to support cloning private terraform modules

### DIFF
--- a/terraform/0.10.8.yml
+++ b/terraform/0.10.8.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.1.yml
+++ b/terraform/0.11.1.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.3.yml
+++ b/terraform/0.11.3.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.4.yml
+++ b/terraform/0.11.4.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.5.yml
+++ b/terraform/0.11.5.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.6.yml
+++ b/terraform/0.11.6.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.7.yml
+++ b/terraform/0.11.7.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/0.11.8.yml
+++ b/terraform/0.11.8.yml
@@ -24,6 +24,7 @@ params:
   access_key:
   secret_key:
   session_token:
+  access_token:
 
 run:
   path: common-tasks/terraform/terraform.sh

--- a/terraform/terraform.sh
+++ b/terraform/terraform.sh
@@ -22,6 +22,11 @@ setup() {
     export AWS_ACCESS_KEY_ID="${access_key}"
     export AWS_SECRET_ACCESS_KEY="${secret_key}"
     export AWS_SESSION_TOKEN="${session_token}"
+
+    if [ "${access_token}" != "" ]; then
+        rm -f "${HOME}"/.netrc
+        echo "default login x-oauth-basic password ${access_token}" > "${HOME}"/.netrc
+    fi
 }
 
 setup_cache() {


### PR DESCRIPTION
Picked the `.netrc` trick up from here: https://github.com/concourse/git-resource/blob/master/assets/common.sh#L143

Have validated that this works with private repositories - I opted to go with `access_token` because deploy keys can only access a single repository at a time, and I'd rather not introduce a third credential type to "working with concourse". Using an access token also has an added benefit; we don't have to change the `source=github.com` to `git::github.com` for modules.