### PR TITLE
Feat: add Terraform variable(s) to task params

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ as `common-tasks/terraform` to tasks in our job. So to use the task we simply de
       params:
         command: test
         cache: true
+        tf_vars:
+          - TF_VAR_foo: ((foo-secret))
+          - TF_VAR_bar: ((bar-secret))
         directories: |
           terraform/concourse
           terraform/vault

--- a/terraform/terraform.sh
+++ b/terraform/terraform.sh
@@ -32,6 +32,22 @@ setup() {
     if [ ! -z "${github_private_key}" ]; then
         setup_ssh
     fi
+
+    if [ ! -z "$tf_vars" ]; then
+        setup_terraform_variables
+    fi
+}
+
+setup_terraform_variables() {
+    # install jq
+    JQ_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/jq-latest" 
+    curl --silent --show-error --location --fail --retry 3 --output /usr/bin/jq $JQ_URL
+    chmod +x /usr/bin/jq
+    # export Terraform environment variables
+    for obj in $(echo "${tf_vars}" | jq -c '.[]'); do
+        TF_VAR="$(echo ${obj} | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]")"
+        export $TF_VAR
+    done
 }
 
 setup_ssh() {


### PR DESCRIPTION
The changes here to allow passing secrets as Terraform environment variables. 
The secrets can be fetched from a secret store like AWS secrets manager and used in Terraform script.

```
resource "aws_s3_bucket" "b" {
  bucket = "name"
  acl    = "private"

  tags {
    Name        = "${var.foo}"
    Environment = "${var.bar}"
  }
}
```