### PR TITLE
Add Terraform 0.12.7

### DIFF
--- a/terraform/0.12.7.yml
+++ b/terraform/0.12.7.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: hashicorp/terraform
+    tag: "0.12.7"
+
+inputs:
+- name: source
+- name: common-tasks
+
+outputs:
+- name: terraform
+
+caches:
+- path: terraform-cache
+
+params:
+  command:
+  directories:
+  cache: "false"
+  lock_timeout: 5m
+  access_key:
+  secret_key:
+  session_token:
+  github_access_token:
+  github_private_key:
+
+run:
+  path: common-tasks/terraform/terraform-0.12.sh


### PR DESCRIPTION
```
Error refreshing state: state snapshot was created by Terraform v0.12.7, which is newer than current v0.12.6; upgrade to Terraform v0.12.7 or greater to work with this state
```

I accidentally created state with 0.12.7 locally 🤦‍♂ Adding as an option to use in Concourse